### PR TITLE
Fixed a bug for inputs with 0 adjacencies.

### DIFF
--- a/tests/test_torch_dftd3_calculator_zero_adjacency.py
+++ b/tests/test_torch_dftd3_calculator_zero_adjacency.py
@@ -1,0 +1,187 @@
+"""
+DFTD3 program need to be installed to test this method.
+"""
+import tempfile
+from typing import List
+
+import numpy as np
+import pytest
+import torch
+from ase import Atoms
+from ase.build import fcc111, molecule
+from ase.calculators.emt import EMT
+from torch_dftd.testing.damping import damping_method_list, damping_xc_combination_list
+from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
+
+
+def _create_atoms() -> List[Atoms]:
+    """Initialization"""
+    H = molecule("H")
+    H_pbc = molecule("H", vacuum=100.0, pbc=True)
+    null = Atoms()
+    null_pbc = Atoms(cell=np.eye(3) * 100, pbc=True)
+    return [H, H_pbc, null, null_pbc]
+
+
+def _assert_energy_equal(calc, atoms: Atoms):
+    calc.reset()
+    atoms.calc = calc
+    e1 = atoms.get_potential_energy()
+
+    e2 = 0.0
+    assert np.allclose(e1, e2, atol=1e-4, rtol=1e-4)
+
+
+def _test_calc_energy(damping, xc, old, atoms, device="cpu", dtype=torch.float64, abc=False):
+    cutoff = 25.0  # Make test faster
+    torch_dftd3_calc = TorchDFTD3Calculator(
+        damping=damping, xc=xc, device=device, dtype=dtype, old=old, cutoff=cutoff, abc=abc
+    )
+    _assert_energy_equal(torch_dftd3_calc, atoms)
+
+
+def _assert_energy_force_stress_equal(calc, atoms: Atoms):
+    calc.reset()
+    atoms.calc = calc
+    f1 = atoms.get_forces()
+    e1 = atoms.get_potential_energy()
+
+    if calc.dft is not None:
+        calc2 = calc.dft
+        calc2.reset()
+        atoms.calc = calc2
+        e2 = atoms.get_potential_energy()
+        f2 = atoms.get_forces()
+    else:
+        f2 = np.zeros_like(atoms.get_positions())
+        e2 = 0.0
+    assert np.allclose(e1, e2, atol=1e-4, rtol=1e-4), (e1, e2)
+    assert np.allclose(f1, f2, atol=1e-5, rtol=1e-5)
+    if np.all(atoms.pbc == np.array([True, True, True])):
+        s1 = atoms.get_stress()
+        s2 = np.zeros([6])
+        assert np.allclose(s1, s2, atol=1e-5, rtol=1e-5)
+
+
+def _test_calc_energy_force_stress(
+    damping, xc, old, atoms, device="cpu", dtype=torch.float64, abc=False, cnthr=15.0
+):
+    cutoff = 22.0  # Make test faster
+    torch_dftd3_calc = TorchDFTD3Calculator(
+        damping=damping,
+        xc=xc,
+        device=device,
+        dtype=dtype,
+        old=old,
+        cutoff=cutoff,
+        cnthr=cnthr,
+        abc=abc,
+    )
+    _assert_energy_force_stress_equal(torch_dftd3_calc, atoms)
+
+
+@pytest.mark.parametrize("damping,xc,old", damping_xc_combination_list)
+@pytest.mark.parametrize("atoms", _create_atoms())
+def test_calc_energy(damping, xc, old, atoms):
+    """Test1-1: check damping,xc,old combination works for energy"""
+    _test_calc_energy(damping, xc, old, atoms, device="cpu")
+
+
+@pytest.mark.parametrize("damping,xc,old", damping_xc_combination_list)
+@pytest.mark.parametrize("atoms", _create_atoms())
+def test_calc_energy_force_stress(damping, xc, old, atoms):
+    """Test1-2: check damping,xc,old combination works for energy, force & stress"""
+    _test_calc_energy_force_stress(damping, xc, old, atoms, device="cpu")
+
+
+@pytest.mark.parametrize("damping,old", damping_method_list)
+@pytest.mark.parametrize("atoms", _create_atoms())
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_calc_energy_device(damping, old, atoms, device, dtype):
+    """Test2-1: check device, dtype dependency. with only various damping method."""
+    xc = "pbe"
+    _test_calc_energy(damping, xc, old, atoms, device=device, dtype=dtype)
+
+
+@pytest.mark.parametrize("damping,old", damping_method_list)
+@pytest.mark.parametrize("atoms", _create_atoms())
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_calc_energy_force_stress_device(damping, old, atoms, device, dtype):
+    """Test2-2: check device, dtype dependency. with only various damping method."""
+    xc = "pbe"
+    _test_calc_energy_force_stress(damping, xc, old, atoms, device=device, dtype=dtype)
+
+
+@pytest.mark.parametrize("atoms", _create_atoms())
+@pytest.mark.parametrize("damping,old", damping_method_list)
+def test_calc_energy_force_stress_bidirectional(atoms, damping, old):
+    """Test with bidirectional=False"""
+    device = "cpu"
+    xc = "pbe"
+    torch_dftd3_calc = TorchDFTD3Calculator(
+        damping=damping, xc=xc, device=device, old=old, bidirectional=False
+    )
+    if np.all(atoms.pbc):
+        # TODO: bidirectional=False is not implemented for pbc now.
+        with pytest.raises(NotImplementedError):
+            _assert_energy_force_stress_equal(torch_dftd3_calc, atoms)
+    else:
+        _assert_energy_force_stress_equal(torch_dftd3_calc, atoms)
+
+
+@pytest.mark.parametrize("atoms", _create_atoms())
+@pytest.mark.parametrize("damping,old", damping_method_list)
+def test_calc_energy_force_stress_cutoff_smoothing(atoms, damping, old):
+    """Test wit cutoff_smoothing."""
+    device = "cpu"
+    xc = "pbe"
+    cutoff_smoothing = "poly"
+    torch_dftd3_calc = TorchDFTD3Calculator(
+        damping=damping,
+        xc=xc,
+        device=device,
+        old=old,
+        bidirectional=False,
+        cutoff_smoothing=cutoff_smoothing,
+    )
+    try:
+        _assert_energy_force_stress_equal(torch_dftd3_calc, atoms)
+    except NotImplementedError:
+        print("NotImplementedError with atoms", atoms)
+        # sometimes, bidirectional=False is not implemented.
+        pass
+
+
+def test_calc_energy_force_stress_with_dft():
+    """Test with `dft` argument"""
+    atoms = molecule("H")
+    # Set calculator. EMT supports H & C just for fun, which is enough for the test!
+    # https://wiki.fysik.dtu.dk/ase/ase/calculators/emt.html#module-ase.calculators.emt
+    dft = EMT()
+    damping = "bj"
+    old = False
+    device = "cpu"
+    xc = "pbe"
+    torch_dftd3_calc = TorchDFTD3Calculator(
+        damping=damping, xc=xc, device=device, old=old, bidirectional=False, dft=dft
+    )
+    _assert_energy_force_stress_equal(torch_dftd3_calc, atoms)
+
+
+@pytest.mark.parametrize("damping,old", damping_method_list)
+@pytest.mark.parametrize("atoms", _create_atoms())
+@pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+@pytest.mark.parametrize("dtype", [torch.float64])
+@pytest.mark.parametrize("abc", [True])
+def test_calc_energy_force_stress_device_abc(damping, old, atoms, device, dtype, abc):
+    """Test: check tri-partite calc with device, dtype dependency."""
+    xc = "pbe"
+    _test_calc_energy_force_stress(
+        damping, xc, old, atoms, device=device, dtype=dtype, abc=abc, cnthr=7.0
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/torch_dftd/functions/dftd3.py
+++ b/torch_dftd/functions/dftd3.py
@@ -100,7 +100,7 @@ def _getc6(
     else:
         k3_rnc = torch.where(cn0 > 0.0, k3 * r, -1.0e20 * torch.ones_like(r)).view(n_edges, n_c6ab)
     r_ratio = torch.softmax(k3_rnc, dim=1)
-    c6 = (r_ratio * cn0.view(n_edges, 25)).sum(dim=1)
+    c6 = (r_ratio * cn0.view(n_edges, n_c6ab)).sum(dim=1)
     return c6
 
 

--- a/torch_dftd/functions/dftd3.py
+++ b/torch_dftd/functions/dftd3.py
@@ -94,9 +94,13 @@ def _getc6(
     r = (cn1 - nci[:, None, None]) ** 2 + (cn2 - ncj[:, None, None]) ** 2
 
     n_edges = r.shape[0]
-    k3_rnc = torch.where(cn0 > 0.0, k3 * r, -1.0e20 * torch.ones_like(r)).view(n_edges, -1)
+    n_c6ab = r.shape[1] * r.shape[2]
+    if cn0.size(0) == 0:
+        k3_rnc = (k3 * r).view(n_edges, n_c6ab)
+    else:
+        k3_rnc = torch.where(cn0 > 0.0, k3 * r, -1.0e20 * torch.ones_like(r)).view(n_edges, n_c6ab)
     r_ratio = torch.softmax(k3_rnc, dim=1)
-    c6 = (r_ratio * cn0.view(n_edges, -1)).sum(dim=1)
+    c6 = (r_ratio * cn0.view(n_edges, 25)).sum(dim=1)
     return c6
 
 

--- a/torch_dftd/functions/edge_extraction.py
+++ b/torch_dftd/functions/edge_extraction.py
@@ -102,11 +102,14 @@ def calc_edge_index(
     else:
         if not bidirectional:
             raise NotImplementedError("bidirectional=False is not supported")
-
-        try:
-            edge_index, S = calc_neighbor_by_pymatgen(pos, cell, pbc, cutoff)
-        except NotImplementedError:
-            # This is slower.
-            edge_index, S = calc_neighbor_by_ase(pos, cell, pbc, cutoff)
+        if pos.shape[0] == 0:
+            edge_index = torch.zeros([2, 0], dtype=torch.long, device=pos.device)
+            S = torch.zeros_like(pos)
+        else:
+            try:
+                edge_index, S = calc_neighbor_by_pymatgen(pos, cell, pbc, cutoff)
+            except NotImplementedError:
+                # This is slower.
+                edge_index, S = calc_neighbor_by_ase(pos, cell, pbc, cutoff)
 
     return edge_index, S

--- a/torch_dftd/functions/triplets_kernel.py
+++ b/torch_dftd/functions/triplets_kernel.py
@@ -131,7 +131,7 @@ def _calc_triplets_core_gpu(
     if not _cupy_available:
         raise ImportError("Please install cupy to use `_calc_triplets_core_gpu`!")
     device = unique.device
-    n_triplets = torch.sum(counts * (counts - 1) / 2).item()
+    n_triplets = int(torch.sum(counts * (counts - 1) / 2).item())
 
     # (n_triplet_edges, 3)
     triplet_node_index = torch.zeros((n_triplets, 3), dtype=torch.long, device=device)


### PR DESCRIPTION
The _gettc6 routine now works correctly even when the number of adjacencies is 0.
Instead of calling calc_neighbor_by_pymatgen when the number of atoms is 0 and the periodic boundary condition, it now return edge_index, S for adjacency 0.
In my environment, using the result of torch.sum for the size of torch.zeros caused an error, so I changed it to cast the result of sum to int.