### PR TITLE
Bugfix: batch calculation with abc=True

### DIFF
--- a/.flexci/config.pbtxt
+++ b/.flexci/config.pbtxt
@@ -8,6 +8,9 @@ configs {
       disk: 10
       gpu: 1
     }
+    time_limit {
+      seconds: 1800
+    }
     command:
         "bash -x .flexci/pytest_script.sh"
   }

--- a/tests/test_torch_dftd3_calculator.py
+++ b/tests/test_torch_dftd3_calculator.py
@@ -72,7 +72,7 @@ def _assert_energy_force_stress_equal(calc1, calc2, atoms: Atoms):
 
 
 def _test_calc_energy_force_stress(
-    damping, xc, old, atoms, device="cpu", dtype=torch.float64, abc=False, cnthr=15.0
+    damping, xc, old, atoms, device="cpu", dtype=torch.float64, bidirectional=True, abc=False, cnthr=15.0
 ):
     cutoff = 22.0  # Make test faster
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -95,6 +95,7 @@ def _test_calc_energy_force_stress(
             cutoff=cutoff,
             cnthr=cnthr,
             abc=abc,
+            bidirectional=bidirectional,
         )
         _assert_energy_force_stress_equal(dftd3_calc, torch_dftd3_calc, atoms)
 
@@ -201,13 +202,21 @@ def test_calc_energy_force_stress_with_dft():
 @pytest.mark.parametrize("atoms", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float64])
+@pytest.mark.parametrize("bidirectional", [True, False])
 @pytest.mark.parametrize("abc", [True])
-def test_calc_energy_force_stress_device_abc(damping, old, atoms, device, dtype, abc):
+def test_calc_energy_force_stress_device_abc(damping, old, atoms, device, dtype, bidirectional, abc):
     """Test: check tri-partite calc with device, dtype dependency."""
     xc = "pbe"
-    _test_calc_energy_force_stress(
-        damping, xc, old, atoms, device=device, dtype=dtype, abc=abc, cnthr=7.0
-    )
+    if np.all(atoms.pbc) and bidirectional == False:
+        # TODO: bidirectional=False is not implemented for pbc now.
+        with pytest.raises(NotImplementedError):
+            _test_calc_energy_force_stress(
+                damping, xc, old, atoms, device=device, dtype=dtype, bidirectional=bidirectional, abc=abc, cnthr=7.0
+            )
+    else:
+        _test_calc_energy_force_stress(
+            damping, xc, old, atoms, device=device, dtype=dtype, bidirectional=bidirectional, abc=abc, cnthr=7.0
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_torch_dftd3_calculator.py
+++ b/tests/test_torch_dftd3_calculator.py
@@ -72,7 +72,15 @@ def _assert_energy_force_stress_equal(calc1, calc2, atoms: Atoms):
 
 
 def _test_calc_energy_force_stress(
-    damping, xc, old, atoms, device="cpu", dtype=torch.float64, bidirectional=True, abc=False, cnthr=15.0
+    damping,
+    xc,
+    old,
+    atoms,
+    device="cpu",
+    dtype=torch.float64,
+    bidirectional=True,
+    abc=False,
+    cnthr=15.0,
 ):
     cutoff = 22.0  # Make test faster
     with tempfile.TemporaryDirectory() as tmpdirname:
@@ -204,18 +212,36 @@ def test_calc_energy_force_stress_with_dft():
 @pytest.mark.parametrize("dtype", [torch.float64])
 @pytest.mark.parametrize("bidirectional", [True, False])
 @pytest.mark.parametrize("abc", [True])
-def test_calc_energy_force_stress_device_abc(damping, old, atoms, device, dtype, bidirectional, abc):
+def test_calc_energy_force_stress_device_abc(
+    damping, old, atoms, device, dtype, bidirectional, abc
+):
     """Test: check tri-partite calc with device, dtype dependency."""
     xc = "pbe"
     if np.all(atoms.pbc) and bidirectional == False:
         # TODO: bidirectional=False is not implemented for pbc now.
         with pytest.raises(NotImplementedError):
             _test_calc_energy_force_stress(
-                damping, xc, old, atoms, device=device, dtype=dtype, bidirectional=bidirectional, abc=abc, cnthr=7.0
+                damping,
+                xc,
+                old,
+                atoms,
+                device=device,
+                dtype=dtype,
+                bidirectional=bidirectional,
+                abc=abc,
+                cnthr=7.0,
             )
     else:
         _test_calc_energy_force_stress(
-            damping, xc, old, atoms, device=device, dtype=dtype, bidirectional=bidirectional, abc=abc, cnthr=7.0
+            damping,
+            xc,
+            old,
+            atoms,
+            device=device,
+            dtype=dtype,
+            bidirectional=bidirectional,
+            abc=abc,
+            cnthr=7.0,
         )
 
 

--- a/tests/test_torch_dftd3_calculator_batch.py
+++ b/tests/test_torch_dftd3_calculator_batch.py
@@ -13,13 +13,13 @@ from torch_dftd.testing.damping import damping_method_list
 from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
 
 
-def _create_atoms() -> List[Atoms]:
+def _create_atoms() -> List[List[Atoms]]:
     """Initialization"""
     atoms = molecule("CH3CH2OCH3")
 
     slab = fcc111("Au", size=(2, 1, 3), vacuum=80.0)
     slab.pbc = np.array([True, True, True])
-    return [atoms, slab]
+    return [[atoms, slab], []]
 
 
 def _assert_energy_equal_batch(calc1, atoms_list: List[Atoms]):
@@ -77,6 +77,7 @@ def _test_calc_energy_force_stress(
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
+@pytest.mark.parametrize("atom_lists", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_calc_energy_device_batch(damping, old, device, dtype):
@@ -87,6 +88,7 @@ def test_calc_energy_device_batch(damping, old, device, dtype):
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
+@pytest.mark.parametrize("atom_lists", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_calc_energy_force_stress_device_batch(damping, old, device, dtype):
@@ -97,6 +99,7 @@ def test_calc_energy_force_stress_device_batch(damping, old, device, dtype):
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
+@pytest.mark.parametrize("atom_lists", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float64])
 def test_calc_energy_force_stress_device_batch_abc(damping, old, device, dtype):

--- a/tests/test_torch_dftd3_calculator_batch.py
+++ b/tests/test_torch_dftd3_calculator_batch.py
@@ -65,7 +65,15 @@ def _assert_energy_force_stress_equal_batch(calc1, atoms_list: List[Atoms]):
 
 
 def _test_calc_energy_force_stress(
-    damping, xc, old, atoms_list, device="cpu", dtype=torch.float64, bidirectional=True, abc=False, cnthr=15.0
+    damping,
+    xc,
+    old,
+    atoms_list,
+    device="cpu",
+    dtype=torch.float64,
+    bidirectional=True,
+    abc=False,
+    cnthr=15.0,
 ):
     cutoff = 22.0  # Make test faster
     torch_dftd3_calc = TorchDFTD3Calculator(
@@ -107,7 +115,9 @@ def test_calc_energy_force_stress_device_batch(damping, old, atoms_list, device,
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("bidirectional", [True, False])
 @pytest.mark.parametrize("dtype", [torch.float64])
-def test_calc_energy_force_stress_device_batch_abc(damping, old, atoms_list, device, bidirectional, dtype):
+def test_calc_energy_force_stress_device_batch_abc(
+    damping, old, atoms_list, device, bidirectional, dtype
+):
     """Test2-3: check device, dtype dependency. with only various damping method."""
     xc = "pbe"
     abc = True
@@ -115,11 +125,27 @@ def test_calc_energy_force_stress_device_batch_abc(damping, old, atoms_list, dev
         # TODO: bidirectional=False is not implemented for pbc now.
         with pytest.raises(NotImplementedError):
             _test_calc_energy_force_stress(
-                damping, xc, old, atoms_list, device=device, dtype=dtype, bidirectional=bidirectional, abc=abc, cnthr=7.0
+                damping,
+                xc,
+                old,
+                atoms_list,
+                device=device,
+                dtype=dtype,
+                bidirectional=bidirectional,
+                abc=abc,
+                cnthr=7.0,
             )
     else:
         _test_calc_energy_force_stress(
-            damping, xc, old, atoms_list, device=device, dtype=dtype, bidirectional=bidirectional, abc=abc, cnthr=7.0
+            damping,
+            xc,
+            old,
+            atoms_list,
+            device=device,
+            dtype=dtype,
+            bidirectional=bidirectional,
+            abc=abc,
+            cnthr=7.0,
         )
 
 

--- a/tests/test_torch_dftd3_calculator_batch.py
+++ b/tests/test_torch_dftd3_calculator_batch.py
@@ -19,7 +19,9 @@ def _create_atoms() -> List[List[Atoms]]:
 
     slab = fcc111("Au", size=(2, 1, 3), vacuum=80.0)
     slab.pbc = np.array([True, True, True])
-    return [[atoms, slab], []]
+
+    null = Atoms()
+    return [[atoms, slab], [null]]
 
 
 def _assert_energy_equal_batch(calc1, atoms_list: List[Atoms]):

--- a/tests/test_torch_dftd3_calculator_batch.py
+++ b/tests/test_torch_dftd3_calculator_batch.py
@@ -20,8 +20,11 @@ def _create_atoms() -> List[List[Atoms]]:
     slab = fcc111("Au", size=(2, 1, 3), vacuum=80.0)
     slab.pbc = np.array([True, True, True])
 
+    slab_wo_pbc = slab.copy()
+    slab_wo_pbc.pbc = np.array([False, False, False])
+
     null = Atoms()
-    return [[atoms, slab], [null]]
+    return [[atoms, slab], [atoms, slab_wo_pbc], [null]]
 
 
 def _assert_energy_equal_batch(calc1, atoms_list: List[Atoms]):
@@ -62,7 +65,7 @@ def _assert_energy_force_stress_equal_batch(calc1, atoms_list: List[Atoms]):
 
 
 def _test_calc_energy_force_stress(
-    damping, xc, old, atoms_list, device="cpu", dtype=torch.float64, abc=False, cnthr=15.0
+    damping, xc, old, atoms_list, device="cpu", dtype=torch.float64, bidirectional=True, abc=False, cnthr=15.0
 ):
     cutoff = 22.0  # Make test faster
     torch_dftd3_calc = TorchDFTD3Calculator(
@@ -74,6 +77,7 @@ def _test_calc_energy_force_stress(
         cutoff=cutoff,
         cnthr=cnthr,
         abc=abc,
+        bidirectional=bidirectional,
     )
     _assert_energy_force_stress_equal_batch(torch_dftd3_calc, atoms_list)
 
@@ -101,14 +105,22 @@ def test_calc_energy_force_stress_device_batch(damping, old, atoms_list, device,
 @pytest.mark.parametrize("damping,old", damping_method_list)
 @pytest.mark.parametrize("atoms_list", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
+@pytest.mark.parametrize("bidirectional", [True, False])
 @pytest.mark.parametrize("dtype", [torch.float64])
-def test_calc_energy_force_stress_device_batch_abc(damping, old, atoms_list, device, dtype):
+def test_calc_energy_force_stress_device_batch_abc(damping, old, atoms_list, device, bidirectional, dtype):
     """Test2-3: check device, dtype dependency. with only various damping method."""
     xc = "pbe"
     abc = True
-    _test_calc_energy_force_stress(
-        damping, xc, old, atoms_list, device=device, dtype=dtype, abc=abc, cnthr=7.0
-    )
+    if any([np.all(atoms.pbc) for atoms in atoms_list]) and bidirectional == False:
+        # TODO: bidirectional=False is not implemented for pbc now.
+        with pytest.raises(NotImplementedError):
+            _test_calc_energy_force_stress(
+                damping, xc, old, atoms_list, device=device, dtype=dtype, bidirectional=bidirectional, abc=abc, cnthr=7.0
+            )
+    else:
+        _test_calc_energy_force_stress(
+            damping, xc, old, atoms_list, device=device, dtype=dtype, bidirectional=bidirectional, abc=abc, cnthr=7.0
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_torch_dftd3_calculator_batch.py
+++ b/tests/test_torch_dftd3_calculator_batch.py
@@ -100,12 +100,12 @@ def test_calc_energy_force_stress_device_batch(damping, old, device, dtype):
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float64])
 def test_calc_energy_force_stress_device_batch_abc(damping, old, device, dtype):
-    """Test2-2: check device, dtype dependency. with only various damping method."""
+    """Test2-3: check device, dtype dependency. with only various damping method."""
     xc = "pbe"
     abc = True
     atoms_list = _create_atoms()
     _test_calc_energy_force_stress(
-        damping, xc, old, atoms_list, device=device, dtype=dtype, cnthr=7.0
+        damping, xc, old, atoms_list, device=device, dtype=dtype, abc=abc, cnthr=7.0
     )
 
 

--- a/tests/test_torch_dftd3_calculator_batch.py
+++ b/tests/test_torch_dftd3_calculator_batch.py
@@ -77,36 +77,33 @@ def _test_calc_energy_force_stress(
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atom_lists", _create_atoms())
+@pytest.mark.parametrize("atoms_list", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-def test_calc_energy_device_batch(damping, old, device, dtype):
+def test_calc_energy_device_batch(damping, old, atoms_list, device, dtype):
     """Test2-1: check device, dtype dependency. with only various damping method."""
     xc = "pbe"
-    atoms_list = _create_atoms()
     _test_calc_energy(damping, xc, old, atoms_list, device=device, dtype=dtype)
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atom_lists", _create_atoms())
+@pytest.mark.parametrize("atoms_list", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-def test_calc_energy_force_stress_device_batch(damping, old, device, dtype):
+def test_calc_energy_force_stress_device_batch(damping, old, atoms_list, device, dtype):
     """Test2-2: check device, dtype dependency. with only various damping method."""
     xc = "pbe"
-    atoms_list = _create_atoms()
     _test_calc_energy_force_stress(damping, xc, old, atoms_list, device=device, dtype=dtype)
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atom_lists", _create_atoms())
+@pytest.mark.parametrize("atoms_list", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float64])
-def test_calc_energy_force_stress_device_batch_abc(damping, old, device, dtype):
+def test_calc_energy_force_stress_device_batch_abc(damping, old, atoms_list, device, dtype):
     """Test2-3: check device, dtype dependency. with only various damping method."""
     xc = "pbe"
     abc = True
-    atoms_list = _create_atoms()
     _test_calc_energy_force_stress(
         damping, xc, old, atoms_list, device=device, dtype=dtype, abc=abc, cnthr=7.0
     )

--- a/torch_dftd/functions/dftd2.py
+++ b/torch_dftd/functions/dftd2.py
@@ -72,7 +72,10 @@ def edisp_d2(
         g = e6.sum()[None]
     else:
         # (n_graphs,)
-        n_graphs = int(batch[-1]) + 1
+        if batch.size()[0] == 0:
+            n_graphs = 1
+        else:
+            n_graphs = int(batch[-1]) + 1
         g = e6.new_zeros((n_graphs,))
         g.scatter_add_(0, batch_edge, e6)
 

--- a/torch_dftd/nn/base_dftd_module.py
+++ b/torch_dftd/nn/base_dftd_module.py
@@ -78,7 +78,10 @@ class BaseDFTDModule(nn.Module):
         if batch is None:
             return [{"energy": E_disp.item()}]
         else:
-            n_graphs = int(batch[-1]) + 1
+            if batch.size()[0] == 0:
+                n_graphs = 1
+            else:
+                n_graphs = int(batch[-1]) + 1
             return [{"energy": E_disp[i].item()} for i in range(n_graphs)]
 
     def calc_energy_and_forces(

--- a/torch_dftd/nn/base_dftd_module.py
+++ b/torch_dftd/nn/base_dftd_module.py
@@ -133,7 +133,10 @@ class BaseDFTDModule(nn.Module):
         if batch is None:
             results_list = [{"energy": E_disp.item(), "forces": forces.cpu().numpy()}]
         else:
-            n_graphs = int(batch[-1]) + 1
+            if batch.size()[0] == 0:
+                n_graphs = 1
+            else:
+                n_graphs = int(batch[-1]) + 1
             results_list = [{"energy": E_disp[i].item()} for i in range(n_graphs)]
             for i in range(n_graphs):
                 results_list[i]["forces"] = forces[batch == i].cpu().numpy()

--- a/torch_dftd/torch_dftd3_calculator.py
+++ b/torch_dftd/torch_dftd3_calculator.py
@@ -166,10 +166,8 @@ class TorchDFTD3Calculator(Calculator):
         )
         batch_dicts = dict(
             Z=torch.cat([d["Z"] for d in input_dicts_list], dim=0),  # (n_nodes,)
-            pos=torch.cat([d["pos"] for d in input_dicts_list], dim=0).requires_grad_(
-                True
-            ),  # (n_nodes,)
-            cell=cell_batch.requires_grad_(True),  # (bs, 3, 3)
+            pos=torch.cat([d["pos"] for d in input_dicts_list], dim=0),  # (n_nodes,)
+            cell=cell_batch,  # (bs, 3, 3)
             pbc=torch.stack([d["pbc"] for d in input_dicts_list]),  # (bs, 3)
             shift=torch.cat([d["shift"] for d in input_dicts_list], dim=0),  # (n_nodes,)
         )

--- a/torch_dftd/torch_dftd3_calculator.py
+++ b/torch_dftd/torch_dftd3_calculator.py
@@ -156,14 +156,17 @@ class TorchDFTD3Calculator(Calculator):
         # pos=pos, Z=Z, cell=cell, pbc=pbc, edge_index=edge_index, shift=S
         n_nodes_list = [d["Z"].shape[0] for d in input_dicts_list]
         shift_index_array = torch.cumsum(torch.tensor([0] + n_nodes_list), dim=0)
-        cell_batch = torch.stack(
-            [
-                torch.eye(3, device=self.device, dtype=self.dtype)
-                if d["cell"] is None
-                else d["cell"]
-                for d in input_dicts_list
-            ]
-        )
+        if len(input_dicts_list) == 0:
+            cell_batch = torch.zeros((0, 3, 3))
+        else:
+            cell_batch = torch.stack(
+                [
+                    torch.eye(3, device=self.device, dtype=self.dtype)
+                    if d["cell"] is None
+                    else d["cell"]
+                    for d in input_dicts_list
+                ]
+            )
         batch_dicts = dict(
             Z=torch.cat([d["Z"] for d in input_dicts_list], dim=0),  # (n_nodes,)
             pos=torch.cat([d["pos"] for d in input_dicts_list], dim=0),  # (n_nodes,)

--- a/torch_dftd/torch_dftd3_calculator.py
+++ b/torch_dftd/torch_dftd3_calculator.py
@@ -156,17 +156,14 @@ class TorchDFTD3Calculator(Calculator):
         # pos=pos, Z=Z, cell=cell, pbc=pbc, edge_index=edge_index, shift=S
         n_nodes_list = [d["Z"].shape[0] for d in input_dicts_list]
         shift_index_array = torch.cumsum(torch.tensor([0] + n_nodes_list), dim=0)
-        if len(input_dicts_list) == 0:
-            cell_batch = torch.zeros((0, 3, 3))
-        else:
-            cell_batch = torch.stack(
-                [
-                    torch.eye(3, device=self.device, dtype=self.dtype)
-                    if d["cell"] is None
-                    else d["cell"]
-                    for d in input_dicts_list
-                ]
-            )
+        cell_batch = torch.stack(
+            [
+                torch.eye(3, device=self.device, dtype=self.dtype)
+                if d["cell"] is None
+                else d["cell"]
+                for d in input_dicts_list
+            ]
+        )
         batch_dicts = dict(
             Z=torch.cat([d["Z"] for d in input_dicts_list], dim=0),  # (n_nodes,)
             pos=torch.cat([d["pos"] for d in input_dicts_list], dim=0),  # (n_nodes,)

--- a/torch_dftd/torch_dftd3_calculator.py
+++ b/torch_dftd/torch_dftd3_calculator.py
@@ -166,8 +166,10 @@ class TorchDFTD3Calculator(Calculator):
         )
         batch_dicts = dict(
             Z=torch.cat([d["Z"] for d in input_dicts_list], dim=0),  # (n_nodes,)
-            pos=torch.cat([d["pos"] for d in input_dicts_list], dim=0),  # (n_nodes,)
-            cell=cell_batch,  # (bs, 3, 3)
+            pos=torch.cat([d["pos"] for d in input_dicts_list], dim=0).requires_grad_(
+                True
+            ),  # (n_nodes,)
+            cell=cell_batch.requires_grad_(True),  # (bs, 3, 3)
             pbc=torch.stack([d["pbc"] for d in input_dicts_list]),  # (bs, 3)
             shift=torch.cat([d["shift"] for d in input_dicts_list], dim=0),  # (n_nodes,)
         )


### PR DESCRIPTION
I found that test function `test_calc_energy_force_stress_device_batch_abc` unintentionally ignores `abc` argument.

This PR modified related implementation to work it.

In addition, corner case correspondence when the total number of atom is zero is also added. (`n_graphs` cannot be calculated from `batch_edge` when `len(batch_edge) == 0`.)