### PR TITLE
move pysen to develop dependency

### DIFF
--- a/.flexci/pytest_script.sh
+++ b/.flexci/pytest_script.sh
@@ -21,7 +21,7 @@ main() {
     ${IMAGE} \
     bash -x -c "pip install flake8 pytest pytest-cov pytest-xdist pytest-benchmark && \
       pip install cupy-cuda102 pytorch-pfn-extras && \
-      pip install -e . && \
+      pip install -e .[develop] && \
       pysen run lint && \
       pytest --cov=torch_dftd -n $(nproc) -m 'not slow' tests &&
       pytest --benchmark-only tests"

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     packages=find_packages(),
     setup_requires=setup_requires,
     install_requires=install_requires,
+    extras_require=extras_require,
     include_package_data=True,
     package_data=package_data,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import Dict, List
 
 from setuptools import find_packages, setup  # NOQA
 
@@ -7,8 +7,10 @@ setup_requires: List[str] = []
 install_requires: List[str] = [
     "ase>=3.18, <4.0.0",  # Note that we require ase==3.21.1 for pytest.
     "pymatgen",
-    "pysen[lint]==0.9.1",
 ]
+extras_require: Dict[str, List[str]] = {
+    "develop": ["pysen[lint]==0.9.1"],
+}
 
 
 __version__: str


### PR DESCRIPTION
I think we can remove linter tools from prerequisites.