### PR TITLE
use shift for gradient calculation instead of cell

### DIFF
--- a/.flexci/config.pbtxt
+++ b/.flexci/config.pbtxt
@@ -3,8 +3,8 @@ configs {
   key: "torch-dftd.pytest"
   value {
     requirement {
-      cpu: 4
-      memory: 24
+      cpu: 6
+      memory: 36
       disk: 10
       gpu: 1
     }

--- a/.flexci/pytest_script.sh
+++ b/.flexci/pytest_script.sh
@@ -20,7 +20,7 @@ main() {
   docker run --runtime=nvidia --rm --volume="$(pwd)":/workspace -w /workspace \
     ${IMAGE} \
     bash -x -c "pip install flake8 pytest pytest-cov pytest-xdist pytest-benchmark && \
-      pip install cupy-cuda102 pytorch-pfn-extras && \
+      pip install cupy-cuda102 pytorch-pfn-extras!=0.5.0 && \
       pip install -e .[develop] && \
       pysen run lint && \
       pytest --cov=torch_dftd -n $(nproc) -m 'not slow' tests &&

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[tool:pytest]
+markers =
+    slow: mark test as slow.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages, setup  # NOQA
 setup_requires: List[str] = []
 install_requires: List[str] = [
     "ase>=3.18, <4.0.0",  # Note that we require ase==3.21.1 for pytest.
-    "pymatgen",
+    "pymatgen>=2020.1.28",
 ]
 extras_require: Dict[str, List[str]] = {
     "develop": ["pysen[lint]==0.9.1"],

--- a/tests/functions_tests/test_triplets.py
+++ b/tests/functions_tests/test_triplets.py
@@ -13,12 +13,14 @@ def test_calc_triplets():
         dtype=torch.long,
         device=device,
     )
-    shift = torch.zeros((edge_index.shape[1], 3), dtype=torch.float32, device=device)
-    shift[:, 0] = torch.tensor(
+    shift_pos = torch.zeros((edge_index.shape[1], 3), dtype=torch.float32, device=device)
+    shift_pos[:, 0] = torch.tensor(
         [1, 2, 3, 4, 5, 6, -1, -2, -3, -4, -5, -6], dtype=torch.float32, device=device
     )
     # print("shift", shift.shape)
-    triplet_node_index, multiplicity, edge_jk, batch_triplets = calc_triplets(edge_index, shift)
+    triplet_node_index, multiplicity, edge_jk, batch_triplets = calc_triplets(
+        edge_index, shift_pos
+    )
     # print("triplet_node_index", triplet_node_index.shape, triplet_node_index)
     # print("multiplicity", multiplicity.shape, multiplicity)
     # print("triplet_shift", triplet_shift.shape, triplet_shift)
@@ -44,9 +46,9 @@ def test_calc_triplets():
     # shift for edge `i->j`, `i->k`, `j->k`.
     triplet_shift = torch.stack(
         [
-            -shift[edge_jk[:, 0]],
-            -shift[edge_jk[:, 1]],
-            shift[edge_jk[:, 0]] - shift[edge_jk[:, 1]],
+            -shift_pos[edge_jk[:, 0]],
+            -shift_pos[edge_jk[:, 1]],
+            shift_pos[edge_jk[:, 0]] - shift_pos[edge_jk[:, 1]],
         ],
         dim=1,
     )

--- a/tests/test_torch_dftd3_calculator.py
+++ b/tests/test_torch_dftd3_calculator.py
@@ -8,20 +8,35 @@ import numpy as np
 import pytest
 import torch
 from ase import Atoms
-from ase.build import fcc111, molecule
+from ase.build import bulk, fcc111, molecule
 from ase.calculators.dftd3 import DFTD3
 from ase.calculators.emt import EMT
 from torch_dftd.testing.damping import damping_method_list, damping_xc_combination_list
 from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
 
 
-def _create_atoms() -> List[Atoms]:
+@pytest.fixture(
+    params=[
+        pytest.param("mol", id="mol"),
+        pytest.param("slab", id="slab"),
+        pytest.param("large", marks=[pytest.mark.slow], id="large"),
+    ]
+)
+def atoms(request) -> Atoms:
     """Initialization"""
-    atoms = molecule("CH3CH2OCH3")
+    mol = molecule("CH3CH2OCH3")
 
     slab = fcc111("Au", size=(2, 1, 3), vacuum=80.0)
+    slab.set_cell(
+        slab.get_cell().array @ np.array([[1.0, 0.1, 0.2], [0.0, 1.0, 0.3], [0.0, 0.0, 1.0]])
+    )
     slab.pbc = np.array([True, True, True])
-    return [atoms, slab]
+
+    large_bulk = bulk("Pt", "fcc") * (4, 4, 4)
+
+    atoms_dict = {"mol": mol, "slab": slab, "large": large_bulk}
+
+    return atoms_dict[request.param]
 
 
 def _assert_energy_equal(calc1, calc2, atoms: Atoms):
@@ -53,20 +68,21 @@ def _test_calc_energy(damping, xc, old, atoms, device="cpu", dtype=torch.float64
         _assert_energy_equal(dftd3_calc, torch_dftd3_calc, atoms)
 
 
-def _assert_energy_force_stress_equal(calc1, calc2, atoms: Atoms):
+def _assert_energy_force_stress_equal(calc1, calc2, atoms: Atoms, force_tol: float = 1e-5):
     calc1.reset()
     atoms.calc = calc1
     f1 = atoms.get_forces()
     e1 = atoms.get_potential_energy()
+    if np.all(atoms.pbc == np.array([True, True, True])):
+        s1 = atoms.get_stress()
 
     calc2.reset()
     atoms.calc = calc2
     f2 = atoms.get_forces()
     e2 = atoms.get_potential_energy()
     assert np.allclose(e1, e2, atol=1e-4, rtol=1e-4)
-    assert np.allclose(f1, f2, atol=1e-5, rtol=1e-5)
+    assert np.allclose(f1, f2, atol=force_tol, rtol=force_tol)
     if np.all(atoms.pbc == np.array([True, True, True])):
-        s1 = atoms.get_stress()
         s2 = atoms.get_stress()
         assert np.allclose(s1, s2, atol=1e-5, rtol=1e-5)
 
@@ -83,6 +99,9 @@ def _test_calc_energy_force_stress(
     cnthr=15.0,
 ):
     cutoff = 22.0  # Make test faster
+    force_tol = 1e-5
+    if dtype == torch.float32:
+        force_tol = 1.0e-4
     with tempfile.TemporaryDirectory() as tmpdirname:
         dftd3_calc = DFTD3(
             damping=damping,
@@ -105,25 +124,22 @@ def _test_calc_energy_force_stress(
             abc=abc,
             bidirectional=bidirectional,
         )
-        _assert_energy_force_stress_equal(dftd3_calc, torch_dftd3_calc, atoms)
+        _assert_energy_force_stress_equal(dftd3_calc, torch_dftd3_calc, atoms, force_tol=force_tol)
 
 
 @pytest.mark.parametrize("damping,xc,old", damping_xc_combination_list)
-@pytest.mark.parametrize("atoms", _create_atoms())
 def test_calc_energy(damping, xc, old, atoms):
     """Test1-1: check damping,xc,old combination works for energy"""
     _test_calc_energy(damping, xc, old, atoms, device="cpu")
 
 
 @pytest.mark.parametrize("damping,xc,old", damping_xc_combination_list)
-@pytest.mark.parametrize("atoms", _create_atoms())
 def test_calc_energy_force_stress(damping, xc, old, atoms):
     """Test1-2: check damping,xc,old combination works for energy, force & stress"""
     _test_calc_energy_force_stress(damping, xc, old, atoms, device="cpu")
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atoms", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_calc_energy_device(damping, old, atoms, device, dtype):
@@ -133,7 +149,6 @@ def test_calc_energy_device(damping, old, atoms, device, dtype):
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atoms", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_calc_energy_force_stress_device(damping, old, atoms, device, dtype):
@@ -142,7 +157,6 @@ def test_calc_energy_force_stress_device(damping, old, atoms, device, dtype):
     _test_calc_energy_force_stress(damping, xc, old, atoms, device=device, dtype=dtype)
 
 
-@pytest.mark.parametrize("atoms", _create_atoms())
 @pytest.mark.parametrize("damping,old", damping_method_list)
 def test_calc_energy_force_stress_bidirectional(atoms, damping, old):
     """Test with bidirectional=False"""
@@ -161,7 +175,6 @@ def test_calc_energy_force_stress_bidirectional(atoms, damping, old):
             _assert_energy_force_stress_equal(dftd3_calc, torch_dftd3_calc, atoms)
 
 
-@pytest.mark.parametrize("atoms", _create_atoms())
 @pytest.mark.parametrize("damping,old", damping_method_list)
 def test_calc_energy_force_stress_cutoff_smoothing(atoms, damping, old):
     """Test wit cutoff_smoothing."""
@@ -207,7 +220,6 @@ def test_calc_energy_force_stress_with_dft():
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atoms", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float64])
 @pytest.mark.parametrize("bidirectional", [True, False])

--- a/tests/test_torch_dftd3_calculator_batch.py
+++ b/tests/test_torch_dftd3_calculator_batch.py
@@ -8,14 +8,22 @@ import numpy as np
 import pytest
 import torch
 from ase import Atoms
-from ase.build import fcc111, molecule
+from ase.build import bulk, fcc111, molecule
 from torch_dftd.testing.damping import damping_method_list
 from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
 
 
-def _create_atoms() -> List[List[Atoms]]:
+@pytest.fixture(
+    params=[
+        pytest.param("case1", id="mol+slab"),
+        pytest.param("case2", id="mol+slab(wo_pbc)"),
+        pytest.param("case3", id="null"),
+        pytest.param("case4", marks=[pytest.mark.slow], id="large"),
+    ]
+)
+def atoms_list(request) -> List[Atoms]:
     """Initialization"""
-    atoms = molecule("CH3CH2OCH3")
+    mol = molecule("CH3CH2OCH3")
 
     slab = fcc111("Au", size=(2, 1, 3), vacuum=80.0)
     slab.pbc = np.array([True, True, True])
@@ -24,7 +32,17 @@ def _create_atoms() -> List[List[Atoms]]:
     slab_wo_pbc.pbc = np.array([False, False, False])
 
     null = Atoms()
-    return [[atoms, slab], [atoms, slab_wo_pbc], [null]]
+
+    large_bulk = bulk("Pt", "fcc") * (8, 8, 8)
+
+    atoms_dict = {
+        "case1": [mol, slab],
+        "case2": [mol, slab_wo_pbc],
+        "case3": [null],
+        "case4": [large_bulk],
+    }
+
+    return atoms_dict[request.param]
 
 
 def _assert_energy_equal_batch(calc1, atoms_list: List[Atoms]):
@@ -91,7 +109,6 @@ def _test_calc_energy_force_stress(
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atoms_list", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_calc_energy_device_batch(damping, old, atoms_list, device, dtype):
@@ -101,7 +118,6 @@ def test_calc_energy_device_batch(damping, old, atoms_list, device, dtype):
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atoms_list", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 def test_calc_energy_force_stress_device_batch(damping, old, atoms_list, device, dtype):
@@ -111,7 +127,6 @@ def test_calc_energy_force_stress_device_batch(damping, old, atoms_list, device,
 
 
 @pytest.mark.parametrize("damping,old", damping_method_list)
-@pytest.mark.parametrize("atoms_list", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 @pytest.mark.parametrize("bidirectional", [True, False])
 @pytest.mark.parametrize("dtype", [torch.float64])

--- a/tests/test_torch_dftd3_calculator_benchmark.py
+++ b/tests/test_torch_dftd3_calculator_benchmark.py
@@ -4,19 +4,30 @@ from typing import List
 import numpy as np
 import pytest
 from ase import Atoms
-from ase.build import fcc111, molecule
+from ase.build import bulk, fcc111, molecule
 from ase.calculators.dftd3 import DFTD3
 from ase.units import Bohr
 from torch_dftd.torch_dftd3_calculator import TorchDFTD3Calculator
 
 
-def _create_atoms() -> List[Atoms]:
+@pytest.fixture(
+    params=[
+        pytest.param("mol", id="mol"),
+        pytest.param("slab", id="slab"),
+        pytest.param("large", marks=[pytest.mark.slow], id="large"),
+    ]
+)
+def atoms(request) -> Atoms:
     """Initialization"""
-    atoms = molecule("CH3CH2OCH3")
+    mol = molecule("CH3CH2OCH3")
 
     slab = fcc111("Au", size=(2, 1, 3), vacuum=80.0)
     slab.pbc = np.array([True, True, True])
-    return [atoms, slab]
+
+    large_bulk = bulk("Pt", "fcc") * (4, 4, 4)
+
+    atoms_dict = {"mol": mol, "slab": slab, "large": large_bulk}
+    return atoms_dict[request.param]
 
 
 def calc_energy(calculator, atoms):
@@ -35,7 +46,6 @@ def calc_force_stress(calculator, atoms):
     return True
 
 
-@pytest.mark.parametrize("atoms", _create_atoms())
 def test_dftd3_calculator_benchmark(atoms, benchmark):
     damping = "bj"
     xc = "pbe"
@@ -53,7 +63,6 @@ def test_dftd3_calculator_benchmark(atoms, benchmark):
         )
 
 
-@pytest.mark.parametrize("atoms", _create_atoms())
 @pytest.mark.parametrize("device", ["cpu", "cuda:0"])
 def test_torch_dftd3_calculator_benchmark(atoms, device, benchmark):
     damping = "bj"

--- a/torch_dftd/functions/dftd3.py
+++ b/torch_dftd/functions/dftd3.py
@@ -117,7 +117,7 @@ def edisp(
     cnthr: Optional[float] = None,
     batch: Optional[Tensor] = None,
     batch_edge: Optional[Tensor] = None,
-    shift: Optional[Tensor] = None,
+    shift_pos: Optional[Tensor] = None,
     pos: Optional[Tensor] = None,
     cell: Optional[Tensor] = None,
     r2=None,
@@ -146,7 +146,7 @@ def edisp(
         cnthr (float or None): cutoff distance for coordination number calculation in **bohr**
         batch (Tensor or None): (n_atoms,)
         batch_edge (Tensor or None): (n_edges,)
-        shift (Tensor or None): (n_atoms,) used to calculate 3-body term when abc=True
+        shift_pos (Tensor or None): (n_atoms,) used to calculate 3-body term when abc=True
         pos (Tensor): (n_atoms, 3) position in **bohr**
         cell (Tensor): (3, 3) cell size in **bohr**
         r2 (Tensor or None):
@@ -267,7 +267,7 @@ def edisp(
         edge_index_abc = edge_index[:, within_cutoff]
         batch_edge_abc = None if batch_edge is None else batch_edge[within_cutoff]
         # c6_abc = c6[within_cutoff]
-        shift_abc = None if shift is None else shift[within_cutoff]
+        shift_abc = None if shift_pos is None else shift_pos[within_cutoff]
 
         n_atoms = Z.shape[0]
         if not bidirectional:
@@ -290,7 +290,7 @@ def edisp(
             batch_triplets: Optional[Tensor]
             triplet_node_index, multiplicity, edge_jk, batch_triplets = calc_triplets(
                 edge_index_abc,
-                shift=shift_abc,
+                shift_pos=shift_abc,
                 dtype=pos.dtype,
                 batch_edge=batch_edge_abc,
             )

--- a/torch_dftd/functions/dftd3.py
+++ b/torch_dftd/functions/dftd3.py
@@ -298,10 +298,12 @@ def edisp(
 
         # Apply `cnthr` cutoff threshold for r_kj
         idx_j, idx_k = triplet_node_index[:, 1], triplet_node_index[:, 2]
-        ts2 = None if shift_abc is None else shift_abc[edge_jk[:, 0]] - shift_abc[edge_jk[:, 1]]
-        r_jk = calc_distances(pos, torch.stack([idx_j, idx_k], dim=0), cell, ts2)
+        shift_jk = (
+            None if shift_abc is None else shift_abc[edge_jk[:, 0]] - shift_abc[edge_jk[:, 1]]
+        )
+        r_jk = calc_distances(pos, torch.stack([idx_j, idx_k], dim=0), cell, shift_jk)
         kj_within_cutoff = r_jk <= cnthr
-        del ts2
+        del shift_jk
 
         triplet_node_index = triplet_node_index[kj_within_cutoff]
         multiplicity, edge_jk, batch_triplets = (
@@ -315,11 +317,11 @@ def edisp(
             triplet_node_index[:, 1],
             triplet_node_index[:, 2],
         )
-        ts0 = None if shift_abc is None else -shift_abc[edge_jk[:, 0]]
-        ts1 = None if shift_abc is None else -shift_abc[edge_jk[:, 1]]
+        shift_ij = None if shift_abc is None else -shift_abc[edge_jk[:, 0]]
+        shift_ik = None if shift_abc is None else -shift_abc[edge_jk[:, 1]]
 
-        r_ij = calc_distances(pos, torch.stack([idx_i, idx_j], dim=0), cell, ts0)
-        r_ik = calc_distances(pos, torch.stack([idx_i, idx_k], dim=0), cell, ts1)
+        r_ij = calc_distances(pos, torch.stack([idx_i, idx_j], dim=0), cell, shift_ij)
+        r_ik = calc_distances(pos, torch.stack([idx_i, idx_k], dim=0), cell, shift_ik)
         r_jk = r_jk[kj_within_cutoff]
 
         Zti, Ztj, Ztk = Z[idx_i], Z[idx_j], Z[idx_k]

--- a/torch_dftd/functions/distance.py
+++ b/torch_dftd/functions/distance.py
@@ -8,7 +8,7 @@ def calc_distances(
     pos: Tensor,
     edge_index: Tensor,
     cell: Optional[Tensor] = None,
-    shift: Optional[Tensor] = None,
+    shift_pos: Optional[Tensor] = None,
     eps=1e-20,
 ) -> Tensor:
     """Distance calculation function.
@@ -17,7 +17,7 @@ def calc_distances(
         pos (Tensor): (n_atoms, 3) atom positions.
         edge_index (Tensor): (2, n_edges) edge_index for graph.
         cell (Tensor): cell size, None for non periodic system.
-        shift (Tensor): (n_edges, 3) position shift vectors of edges owing to the periodic boundary. It should be length unit.
+        shift_pos (Tensor): (n_edges, 3) position shift vectors of edges owing to the periodic boundary. It should be length unit.
         eps (float): Small float value to avoid NaN in backward when the distance is 0.
 
     Returns:
@@ -30,7 +30,7 @@ def calc_distances(
     Ri = pos[idx_i]
     Rj = pos[idx_j]
     if cell is not None:
-        Rj += shift
+        Rj += shift_pos
     # eps is to avoid Nan in backward when Dij = 0 with sqrt.
     Dij = torch.sqrt(torch.sum((Ri - Rj) ** 2, dim=-1) + eps)
     return Dij

--- a/torch_dftd/functions/distance.py
+++ b/torch_dftd/functions/distance.py
@@ -9,7 +9,6 @@ def calc_distances(
     edge_index: Tensor,
     cell: Optional[Tensor] = None,
     shift: Optional[Tensor] = None,
-    batch_edge: Optional[Tensor] = None,
     eps=1e-20,
 ) -> Tensor:
 
@@ -18,13 +17,7 @@ def calc_distances(
     Ri = pos[idx_i]
     Rj = pos[idx_j]
     if cell is not None:
-        if batch_edge is None:
-            # shift (n_edges, 3), cell (3, 3) -> offsets (n_edges, 3)
-            offsets = torch.mm(shift, cell)
-        else:
-            # shift (n_edges, 3), cell[batch] (n_atoms, 3, 3) -> offsets (n_edges, 3)
-            offsets = torch.bmm(shift[:, None, :], cell[batch_edge])[:, 0]
-        Rj += offsets
+        Rj += shift
     # eps is to avoid Nan in backward when Dij = 0 with sqrt.
     Dij = torch.sqrt(torch.sum((Ri - Rj) ** 2, dim=-1) + eps)
     return Dij

--- a/torch_dftd/functions/distance.py
+++ b/torch_dftd/functions/distance.py
@@ -11,6 +11,19 @@ def calc_distances(
     shift: Optional[Tensor] = None,
     eps=1e-20,
 ) -> Tensor:
+    """Distance calculation function.
+
+    Args:
+        pos (Tensor): (n_atoms, 3) atom positions.
+        edge_index (Tensor): (2, n_edges) edge_index for graph.
+        cell (Tensor): cell size, None for non periodic system.
+        shift (Tensor): (n_edges, 3) position shift vectors of edges owing to the periodic boundary. It should be length unit.
+        eps (float): Small float value to avoid NaN in backward when the distance is 0.
+
+    Returns:
+        Dij (Tensor): (n_edges, ) distances of edges
+
+    """
 
     idx_i, idx_j = edge_index
     # calculate interatomic distances

--- a/torch_dftd/functions/triplets.py
+++ b/torch_dftd/functions/triplets.py
@@ -37,8 +37,10 @@ def calc_triplets(
     src = src[sort_inds]
     dst = dst[sort_inds]
 
-    edge_indices = torch.arange(src.shape[0], dtype=torch.long, device=edge_index.device)
-    if shift is not None:
+    if shift is None:
+        edge_indices = torch.arange(src.shape[0], dtype=torch.long, device=edge_index.device)
+    else:
+        edge_indices = torch.arange(shift.shape[0], dtype=torch.long, device=edge_index.device)
         edge_indices = edge_indices[is_larger][sort_inds]
 
     if batch_edge is None:

--- a/torch_dftd/functions/triplets.py
+++ b/torch_dftd/functions/triplets.py
@@ -7,7 +7,7 @@ from torch_dftd.functions.triplets_kernel import _calc_triplets_core_gpu
 
 def calc_triplets(
     edge_index: Tensor,
-    shift: Optional[Tensor] = None,
+    shift_pos: Optional[Tensor] = None,
     dtype=torch.float32,
     batch_edge: Optional[Tensor] = None,
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
@@ -15,7 +15,7 @@ def calc_triplets(
 
     Args:
         edge_index (Tensor): (2, n_edges) edge_index for graph. It must be bidirectional edge.
-        shift (Tensor or None): (n_edges, 3) used to calculate unique atoms when pbc=True.
+        shift_pos (Tensor or None): (n_edges, 3) used to calculate unique atoms when pbc=True.
         dtype: dtype for `multiplicity`
         batch_edge (Tensor or None): Specify batch indices for `edge_index`.
 
@@ -37,10 +37,10 @@ def calc_triplets(
     src = src[sort_inds]
     dst = dst[sort_inds]
 
-    if shift is None:
+    if shift_pos is None:
         edge_indices = torch.arange(src.shape[0], dtype=torch.long, device=edge_index.device)
     else:
-        edge_indices = torch.arange(shift.shape[0], dtype=torch.long, device=edge_index.device)
+        edge_indices = torch.arange(shift_pos.shape[0], dtype=torch.long, device=edge_index.device)
         edge_indices = edge_indices[is_larger][sort_inds]
 
     if batch_edge is None:

--- a/torch_dftd/nn/base_dftd_module.py
+++ b/torch_dftd/nn/base_dftd_module.py
@@ -17,7 +17,7 @@ class BaseDFTDModule(nn.Module):
         edge_index: Tensor,
         cell: Optional[Tensor] = None,
         pbc: Optional[Tensor] = None,
-        shift: Optional[Tensor] = None,
+        shift_pos: Optional[Tensor] = None,
         batch: Optional[Tensor] = None,
         batch_edge: Optional[Tensor] = None,
         damping: str = "zero",
@@ -32,7 +32,7 @@ class BaseDFTDModule(nn.Module):
             edge_index (Tensor): (2, n_edges) edge index within cutoff
             cell (Tensor): (n_atoms, 3) cell size in angstrom, None for non periodic system.
             pbc (Tensor): (bs, 3) pbc condition, None for non periodic system.
-            shift (Tensor): (n_atoms, 3) shift vector
+            shift_pos (Tensor): (n_atoms, 3) shift vector (length unit).
             batch (Tensor): (n_atoms,) Specify which graph this atom belongs to
             batch_edge (Tensor): (n_edges, 3) Specify which graph this edge belongs to
             damping (str):
@@ -49,7 +49,7 @@ class BaseDFTDModule(nn.Module):
         edge_index: Tensor,
         cell: Optional[Tensor] = None,
         pbc: Optional[Tensor] = None,
-        shift: Optional[Tensor] = None,
+        shift_pos: Optional[Tensor] = None,
         batch: Optional[Tensor] = None,
         batch_edge: Optional[Tensor] = None,
         damping: str = "zero",
@@ -64,6 +64,7 @@ class BaseDFTDModule(nn.Module):
             edge_index (Tensor):
             cell (Tensor): cell size in angstrom, None for non periodic system.
             pbc (Tensor): pbc condition, None for non periodic system.
+            shift_pos (Tensor):  (n_atoms, 3) shift vector (length unit).
             batch (Tensor):
             batch_edge (Tensor):
             damping (str): damping method. "zero", "bj", "zerom", "bjm"
@@ -73,7 +74,7 @@ class BaseDFTDModule(nn.Module):
         """
         with torch.no_grad():
             E_disp = self.calc_energy_batch(
-                Z, pos, edge_index, cell, pbc, shift, batch, batch_edge, damping=damping
+                Z, pos, edge_index, cell, pbc, shift_pos, batch, batch_edge, damping=damping
             )
         if batch is None:
             return [{"energy": E_disp.item()}]
@@ -91,7 +92,7 @@ class BaseDFTDModule(nn.Module):
         edge_index: Tensor,
         cell: Optional[Tensor] = None,
         pbc: Optional[Tensor] = None,
-        shift: Optional[Tensor] = None,
+        shift_pos: Optional[Tensor] = None,
         batch: Optional[Tensor] = None,
         batch_edge: Optional[Tensor] = None,
         damping: str = "zero",
@@ -103,6 +104,7 @@ class BaseDFTDModule(nn.Module):
             pos (Tensor): atom positions in angstrom
             cell (Tensor): cell size in angstrom, None for non periodic system.
             pbc (Tensor): pbc condition, None for non periodic system.
+            shift_pos (Tensor):  (n_atoms, 3) shift vector (length unit).
             damping (str): damping method. "zero", "bj", "zerom", "bjm"
 
         Returns:
@@ -117,11 +119,11 @@ class BaseDFTDModule(nn.Module):
             # We need to explicitly include this dependency to calculate cell gradient
             # for stress computation.
             # pos is assumed to be inside "cell", so relative position `rel_pos` lies between 0~1.
-            assert isinstance(shift, Tensor)
-            shift.requires_grad_(True)
+            assert isinstance(shift_pos, Tensor)
+            shift_pos.requires_grad_(True)
 
         E_disp = self.calc_energy_batch(
-            Z, pos, edge_index, cell, pbc, shift, batch, batch_edge, damping=damping
+            Z, pos, edge_index, cell, pbc, shift_pos, batch, batch_edge, damping=damping
         )
 
         E_disp.sum().backward()
@@ -140,7 +142,7 @@ class BaseDFTDModule(nn.Module):
         if cell is not None:
             # stress = torch.mm(cell_grad, cell.T) / cell_volume
             # Get stress in Voigt notation (xx, yy, zz, yz, xz, xy)
-            assert isinstance(shift, Tensor)
+            assert isinstance(shift_pos, Tensor)
             voigt_left = [0, 1, 2, 1, 2, 0]
             voigt_right = [0, 1, 2, 2, 0, 1]
             if batch is None:
@@ -149,7 +151,8 @@ class BaseDFTDModule(nn.Module):
                     (pos[:, voigt_left] * pos.grad[:, voigt_right]).to(torch.float64), dim=0
                 )
                 cell_grad += torch.sum(
-                    (shift[:, voigt_left] * shift.grad[:, voigt_right]).to(torch.float64), dim=0
+                    (shift_pos[:, voigt_left] * shift_pos.grad[:, voigt_right]).to(torch.float64),
+                    dim=0,
                 )
                 stress = cell_grad.to(cell.dtype) / cell_volume
                 results_list[0]["stress"] = stress.detach().cpu().numpy()
@@ -166,7 +169,7 @@ class BaseDFTDModule(nn.Module):
                 cell_grad.scatter_add_(
                     0,
                     batch_edge.view(batch_edge.size()[0], 1).expand(batch_edge.size()[0], 6),
-                    (shift[:, voigt_left] * shift.grad[:, voigt_right]).to(torch.float64),
+                    (shift_pos[:, voigt_left] * shift_pos.grad[:, voigt_right]).to(torch.float64),
                 )
                 stress = cell_grad.to(cell.dtype) / cell_volume[:, None]
                 stress = stress.detach().cpu().numpy()

--- a/torch_dftd/nn/dftd2_module.py
+++ b/torch_dftd/nn/dftd2_module.py
@@ -54,20 +54,22 @@ class DFTD2Module(BaseDFTDModule):
         damping: str = "zero",
     ) -> Tensor:
         """Forward computation to calculate atomic wise dispersion energy"""
+        shift = pos.new_zeros((edge_index.size()[1], 3, 3)) if shift is None else shift
         pos_bohr = pos / d3_autoang  # angstrom -> bohr
         if cell is None:
-            cell_bohr = None
+            cell_bohr: Optional[Tensor] = None
         else:
             cell_bohr = cell / d3_autoang  # angstrom -> bohr
-        r = calc_distances(pos_bohr, edge_index, cell_bohr, shift, batch_edge=batch_edge)
+        shift_bohr = shift / d3_autoang  # angstrom -> bohr
+        r = calc_distances(pos_bohr, edge_index, cell_bohr, shift_bohr)
 
         # E_disp (n_graphs,): Energy in eV unit
         E_disp = d3_autoev * edisp_d2(
             Z,
             r,
             edge_index,
-            c6ab=self.c6ab,
-            r0ab=self.r0ab,
+            c6ab=self.c6ab,  # type:ignore
+            r0ab=self.r0ab,  # type:ignore
             params=self.params,
             damping=damping,
             bidirectional=self.bidirectional,

--- a/torch_dftd/nn/dftd2_module.py
+++ b/torch_dftd/nn/dftd2_module.py
@@ -48,19 +48,19 @@ class DFTD2Module(BaseDFTDModule):
         edge_index: Tensor,
         cell: Optional[Tensor] = None,
         pbc: Optional[Tensor] = None,
-        shift: Optional[Tensor] = None,
+        shift_pos: Optional[Tensor] = None,
         batch: Optional[Tensor] = None,
         batch_edge: Optional[Tensor] = None,
         damping: str = "zero",
     ) -> Tensor:
         """Forward computation to calculate atomic wise dispersion energy"""
-        shift = pos.new_zeros((edge_index.size()[1], 3, 3)) if shift is None else shift
+        shift_pos = pos.new_zeros((edge_index.size()[1], 3, 3)) if shift_pos is None else shift_pos
         pos_bohr = pos / d3_autoang  # angstrom -> bohr
         if cell is None:
             cell_bohr: Optional[Tensor] = None
         else:
             cell_bohr = cell / d3_autoang  # angstrom -> bohr
-        shift_bohr = shift / d3_autoang  # angstrom -> bohr
+        shift_bohr = shift_pos / d3_autoang  # angstrom -> bohr
         r = calc_distances(pos_bohr, edge_index, cell_bohr, shift_bohr)
 
         # E_disp (n_graphs,): Energy in eV unit

--- a/torch_dftd/nn/dftd3_module.py
+++ b/torch_dftd/nn/dftd3_module.py
@@ -70,19 +70,19 @@ class DFTD3Module(BaseDFTDModule):
         edge_index: Tensor,
         cell: Optional[Tensor] = None,
         pbc: Optional[Tensor] = None,
-        shift: Optional[Tensor] = None,
+        shift_pos: Optional[Tensor] = None,
         batch: Optional[Tensor] = None,
         batch_edge: Optional[Tensor] = None,
         damping: str = "zero",
     ) -> Tensor:
         """Forward computation to calculate atomic wise dispersion energy"""
-        shift = pos.new_zeros((edge_index.size()[1], 3, 3)) if shift is None else shift
+        shift_pos = pos.new_zeros((edge_index.size()[1], 3, 3)) if shift_pos is None else shift_pos
         pos_bohr = pos / d3_autoang  # angstrom -> bohr
         if cell is None:
             cell_bohr: Optional[Tensor] = None
         else:
             cell_bohr = cell / d3_autoang  # angstrom -> bohr
-        shift_bohr = shift / d3_autoang  # angstrom -> bohr
+        shift_bohr = shift_pos / d3_autoang  # angstrom -> bohr
         r = calc_distances(pos_bohr, edge_index, cell_bohr, shift_bohr)
         # E_disp (n_graphs,): Energy in eV unit
         E_disp = d3_autoev * edisp(
@@ -98,7 +98,7 @@ class DFTD3Module(BaseDFTDModule):
             cnthr=self.cnthr / Bohr,
             batch=batch,
             batch_edge=batch_edge,
-            shift=shift_bohr,
+            shift_pos=shift_bohr,
             damping=damping,
             cutoff_smoothing=self.cutoff_smoothing,
             bidirectional=self.bidirectional,

--- a/torch_dftd/nn/dftd3_module.py
+++ b/torch_dftd/nn/dftd3_module.py
@@ -76,27 +76,29 @@ class DFTD3Module(BaseDFTDModule):
         damping: str = "zero",
     ) -> Tensor:
         """Forward computation to calculate atomic wise dispersion energy"""
+        shift = pos.new_zeros((edge_index.size()[1], 3, 3)) if shift is None else shift
         pos_bohr = pos / d3_autoang  # angstrom -> bohr
         if cell is None:
-            cell_bohr = None
+            cell_bohr: Optional[Tensor] = None
         else:
             cell_bohr = cell / d3_autoang  # angstrom -> bohr
-        r = calc_distances(pos_bohr, edge_index, cell_bohr, shift, batch_edge=batch_edge)
+        shift_bohr = shift / d3_autoang  # angstrom -> bohr
+        r = calc_distances(pos_bohr, edge_index, cell_bohr, shift_bohr)
         # E_disp (n_graphs,): Energy in eV unit
         E_disp = d3_autoev * edisp(
             Z,
             r,
             edge_index,
-            c6ab=self.c6ab,
-            r0ab=self.r0ab,
-            rcov=self.rcov,
-            r2r4=self.r2r4,
+            c6ab=self.c6ab,  # type:ignore
+            r0ab=self.r0ab,  # type:ignore
+            rcov=self.rcov,  # type:ignore
+            r2r4=self.r2r4,  # type:ignore
             params=self.params,
             cutoff=self.cutoff / Bohr,
             cnthr=self.cnthr / Bohr,
             batch=batch,
             batch_edge=batch_edge,
-            shift=shift,
+            shift=shift_bohr,
             damping=damping,
             cutoff_smoothing=self.cutoff_smoothing,
             bidirectional=self.bidirectional,

--- a/torch_dftd/torch_dftd3_calculator.py
+++ b/torch_dftd/torch_dftd3_calculator.py
@@ -103,10 +103,12 @@ class TorchDFTD3Calculator(Calculator):
         pbc = torch.tensor(atoms.pbc, device=self.device)
         edge_index, S = self._calc_edge_index(pos, cell, pbc)
         if cell is None:
-            shift = S
+            shift_pos = S
         else:
-            shift = torch.mm(S, cell.detach())
-        input_dicts = dict(pos=pos, Z=Z, cell=cell, pbc=pbc, edge_index=edge_index, shift=shift)
+            shift_pos = torch.mm(S, cell.detach())
+        input_dicts = dict(
+            pos=pos, Z=Z, cell=cell, pbc=pbc, edge_index=edge_index, shift_pos=shift_pos
+        )
         return input_dicts
 
     def calculate(self, atoms=None, properties=["energy"], system_changes=all_changes):
@@ -155,7 +157,6 @@ class TorchDFTD3Calculator(Calculator):
         # Calculator.calculate(self, atoms, properties, system_changes)
         input_dicts_list = [self._preprocess_atoms(atoms) for atoms in atoms_list]
         # --- Make batch ---
-        # pos=pos, Z=Z, cell=cell, pbc=pbc, edge_index=edge_index, shift=S
         n_nodes_list = [d["Z"].shape[0] for d in input_dicts_list]
         shift_index_array = torch.cumsum(torch.tensor([0] + n_nodes_list), dim=0)
         cell_batch = torch.stack(
@@ -171,7 +172,7 @@ class TorchDFTD3Calculator(Calculator):
             pos=torch.cat([d["pos"] for d in input_dicts_list], dim=0),  # (n_nodes,)
             cell=cell_batch,  # (bs, 3, 3)
             pbc=torch.stack([d["pbc"] for d in input_dicts_list]),  # (bs, 3)
-            shift=torch.cat([d["shift"] for d in input_dicts_list], dim=0),  # (n_nodes,)
+            shift_pos=torch.cat([d["shift_pos"] for d in input_dicts_list], dim=0),  # (n_nodes,)
         )
 
         batch_dicts["edge_index"] = torch.cat(


### PR DESCRIPTION
I found that the current implementation has several performance issues regarding gradient wrt. `cell`.
This PR modifies it. Since the changes are relatively much, I will put some comments.

Change summary:

* Use `shift` for gradient instead of `cell`.
* `shift` is now length scale instead cell unit.
* Calculate Voigt notation style stress directly

Also, this PR contains bugfix related to sked cell.