### PR TITLE
Update CI

### DIFF
--- a/.flexci/build_and_push.sh
+++ b/.flexci/build_and_push.sh
@@ -31,11 +31,11 @@ docker_build_and_push() {
 
 WAIT_PIDS=""
 
-# PyTorch 1.5 + Python 3.6
-docker_build_and_push torch15 \
-    --build-arg base_image="nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04" \
-    --build-arg python_version="3.6.12" \
-    --build-arg pip_packages="torch==1.5.* torchvision==0.6.* ${TEST_PIP_PACKAGES}" &
+# PyTorch 2.0 + Python 3.10
+docker_build_and_push torch20 \
+    --build-arg base_image="nvidia/cuda:12.2.0-devel-ubuntu20.04" \
+    --build-arg python_version="3.10.11" \
+    --build-arg pip_packages="torch==2.0.* torchvision==0.15.* ${TEST_PIP_PACKAGES}" &
 WAIT_PIDS="$! ${WAIT_PIDS}"
 
 # Wait until the build complete.

--- a/.flexci/build_and_push.sh
+++ b/.flexci/build_and_push.sh
@@ -3,7 +3,7 @@
 IMAGE_BASE="${1:-}"
 IMAGE_PUSH=1
 if [ "${IMAGE_BASE}" = "" ]; then
-  IMAGE_BASE="torch-dftd"
+  IMAGE_BASE="torch-dftd-ci"
   IMAGE_PUSH=0
 fi
 

--- a/.flexci/config.pbtxt
+++ b/.flexci/config.pbtxt
@@ -15,3 +15,18 @@ configs {
         "bash -x .flexci/pytest_script.sh"
   }
 }
+configs {
+  key: "torch-dftd.build-images"
+  value {
+    requirement {
+      cpu: 6
+      memory: 36
+      disk: 10
+    }
+    time_limit {
+      seconds: 1800
+    }
+    command:
+        "/bin/bash -x .flexci/build_and_push.sh asia-northeast1-docker.pkg.dev/pfn-artifactregistry/torch-dftd/torch-dftd-ci"
+  }  
+}

--- a/.flexci/pytest_script.sh
+++ b/.flexci/pytest_script.sh
@@ -17,7 +17,6 @@ main() {
 
 # 1st pytest: when xdist is enabled with `-n $(nproc)`, benchmark is not executed.
 # 2nd pytest: only execute pytest-benchmark.
-  while :; do free -h; sleep 1; done &
   docker run --runtime=nvidia --rm --volume="$(pwd)":/workspace -w /workspace \
     ${IMAGE} \
     bash -x -c "pip install flake8 pytest pytest-cov pytest-xdist pytest-benchmark && \

--- a/.flexci/pytest_script.sh
+++ b/.flexci/pytest_script.sh
@@ -17,6 +17,7 @@ main() {
 
 # 1st pytest: when xdist is enabled with `-n $(nproc)`, benchmark is not executed.
 # 2nd pytest: only execute pytest-benchmark.
+  while :; do free -h; sleep 1; done &
   docker run --runtime=nvidia --rm --volume="$(pwd)":/workspace -w /workspace \
     ${IMAGE} \
     bash -x -c "pip install flake8 pytest pytest-cov pytest-xdist pytest-benchmark && \

--- a/.flexci/pytest_script.sh
+++ b/.flexci/pytest_script.sh
@@ -20,7 +20,7 @@ main() {
   docker run --runtime=nvidia --rm --volume="$(pwd)":/workspace -w /workspace \
     ${IMAGE} \
     bash -x -c "pip install flake8 pytest pytest-cov pytest-xdist pytest-benchmark && \
-      pip install cupy-cuda102 pytorch-pfn-extras!=0.5.0 && \
+      pip install cupy-cuda12x pytorch-pfn-extras!=0.5.0 && \
       pip install -e .[develop] && \
       pysen run lint && \
       pytest --cov=torch_dftd -n $(nproc) -m 'not slow' tests &&

--- a/.flexci/pytest_script.sh
+++ b/.flexci/pytest_script.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eu
 
-#IMAGE=pytorch/pytorch:1.5.1-cuda10.1-cudnn7-devel
-IMAGE=asia.gcr.io/pfn-public-ci/torch-dftd-ci:torch15
+IMAGE=asia-northeast1-docker.pkg.dev/pfn-artifactregistry/torch-dftd/torch-dftd-ci:torch20
+#IMAGE=torch-dftd-ci:torch20
 
 
 main() {

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ print(f"forces {forces}")
 ## Dependency
 
 The library is tested under following environment.
- - python: 3.6
- - CUDA: 10.2
+ - python: 3.10
+ - CUDA: 12.2
 ```bash
-torch==1.5.1
-ase==3.21.1
+torch==2.0.1
+ase==3.22.1
 # Below is only for 3-body term
-cupy-cuda102==8.6.0
-pytorch-pfn-extras==0.3.2
+cupy-cuda12x==12.2.0
+pytorch-pfn-extras==0.7.3
 ```
 
 ## Development tips

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,7 +34,7 @@ RUN pip install -U pip && \
 
 # Install DFTD3
 RUN cd /tmp && \
-  wget https://www.chemie.uni-bonn.de/pctc/mulliken-center/software/dft-d3/dftd3.tgz && \
+  wget https://www.chemiebn.uni-bonn.de/pctc/mulliken-center/software/dft-d3/dft-d3/dftd3.tgz && \
   tar zxvf dftd3.tgz && \
   make && \
   mv dftd3 /usr/local/bin && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.pysen]
-version = "0.9"
+version = "0.10"
 
 [tool.pysen.lint]
 enable_black = true

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires: List[str] = [
     "pymatgen>=2020.1.28",
 ]
 extras_require: Dict[str, List[str]] = {
-    "develop": ["pysen[lint]==0.9.1"],
+    "develop": ["pysen[lint]==0.10.5"],
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ install_requires: List[str] = [
     "pymatgen>=2020.1.28",
 ]
 extras_require: Dict[str, List[str]] = {
-    "develop": ["pysen[lint]==0.10.5"],
+    "develop": ["pysen[lint]==0.10.5", "ase==3.21.1"],
 }
 
 

--- a/torch_dftd/functions/dftd2.py
+++ b/torch_dftd/functions/dftd2.py
@@ -41,8 +41,8 @@ def edisp_d2(
     """
     # compute all necessary powers of the distance
     # square of distances
-    r2 = r ** 2
-    r6 = r2 ** 3
+    r2 = r**2
+    r6 = r2**3
 
     idx_i, idx_j = edge_index
     # compute all necessary quantities

--- a/torch_dftd/functions/dftd3.py
+++ b/torch_dftd/functions/dftd3.py
@@ -165,9 +165,9 @@ def edisp(
     """
     # compute all necessary powers of the distance
     if r2 is None:
-        r2 = r ** 2  # square of distances
+        r2 = r**2  # square of distances
     if r6 is None:
-        r6 = r2 ** 3
+        r6 = r2**3
     if r8 is None:
         r8 = r6 * r2
 
@@ -203,8 +203,8 @@ def edisp(
         # Becke-Johnson damping, zero-damping introduces spurious repulsion
         # and is therefore not supported/implemented
         tmp = a1 * torch.sqrt(c8 / c6) + a2
-        tmp2 = tmp ** 2
-        tmp6 = tmp2 ** 3
+        tmp2 = tmp**2
+        tmp6 = tmp2**3
         tmp8 = tmp6 * tmp2
         e6 = 1 / (r6 + tmp6)
         e8 = 1 / (r8 + tmp8)
@@ -334,19 +334,19 @@ def edisp(
         rav = (4.0 / 3.0) / (rr3_jk * rr3_ij * rr3_ik)
         alp = params["alp"]
         alp8 = alp + 2.0
-        damp = 1.0 / (1.0 + 6.0 * rav ** alp8)
+        damp = 1.0 / (1.0 + 6.0 * rav**alp8)
 
         c6_mem = torch.zeros((n_atoms, n_atoms), dtype=c6.dtype, device=c6.device)
         c6_mem[edge_index[0], edge_index[1]] = c6
         c6_mem[edge_index[1], edge_index[0]] = c6
 
         c9 = torch.sqrt(c6_mem[idx_k, idx_j] * c6_mem[idx_j, idx_i] * c6_mem[idx_i, idx_k])
-        r2ik, r2jk, r2ij = r_ik ** 2, r_jk ** 2, r_ij ** 2
+        r2ik, r2jk, r2ij = r_ik**2, r_jk**2, r_ij**2
         t1 = r2jk + r2ij - r2ik
         t2 = r2ij + r2ik - r2jk
         t3 = r2ik + r2jk - r2ij
         tmp2 = r2ik * r2jk * r2ij
-        ang = (0.375 * t1 * t2 * t3 / tmp2 + 1.0) / (tmp2 ** 1.5)
+        ang = (0.375 * t1 * t2 * t3 / tmp2 + 1.0) / (tmp2**1.5)
         e3 = damp * c9 * ang / multiplicity
 
         # ---------------------------------------------------------------

--- a/torch_dftd/functions/edge_extraction.py
+++ b/torch_dftd/functions/edge_extraction.py
@@ -88,7 +88,7 @@ def calc_edge_index(
         assert cell is None
         # Calculate distance brute force way
         distances = torch.sum((pos.unsqueeze(0) - pos.unsqueeze(1)).pow_(2), dim=2)
-        right_ind, left_ind = torch.where(distances < cutoff ** 2)
+        right_ind, left_ind = torch.where(distances < cutoff**2)
         if bidirectional:
             edge_index = torch.stack(
                 (left_ind[left_ind != right_ind], right_ind[left_ind != right_ind])

--- a/torch_dftd/functions/smoothing.py
+++ b/torch_dftd/functions/smoothing.py
@@ -14,7 +14,7 @@ def poly_smoothing(r: Tensor, cutoff: float) -> Tensor:
     """
     cuton = cutoff - 1
     x = (cutoff - r) / (cutoff - cuton)
-    x2 = x ** 2
+    x2 = x**2
     x3 = x2 * x
     x4 = x3 * x
     x5 = x4 * x

--- a/torch_dftd/nn/params/dftd2_params.py
+++ b/torch_dftd/nn/params/dftd2_params.py
@@ -6,7 +6,7 @@ from torch import Tensor
 # for converting distance from bohr to angstrom
 d3_autoang = 0.52917726
 # J/mol nm^6 - > au
-c6conv = 1.0e-3 / 2625.4999 / (0.052917726 ** 6)
+c6conv = 1.0e-3 / 2625.4999 / (0.052917726**6)
 
 r0 = torch.tensor(
     [


### PR DESCRIPTION
Currently, torch-dftd's CI image is missing because of our image registry transfer. This PR updates the CI condition and also includes the following updates:
- update DFTD3 download link in the Dockerfile
- update the CI environment (Python, CUDA Toolkit, and Pytorch)
- update repository to put the CI image
- update pysen (because of some environment dependency)
- add flex CI project to build and push the CI image

From now on, the CI image is placed at `asia-northeast1-docker.pkg.dev/pfn-artifactregistry/torch-dftd/torch-dftd-ci:torch20`