### PR TITLE
use `get_cell().array`

### DIFF
--- a/torch_dftd/torch_dftd3_calculator.py
+++ b/torch_dftd/torch_dftd3_calculator.py
@@ -96,7 +96,7 @@ class TorchDFTD3Calculator(Calculator):
         Z = torch.tensor(atoms.get_atomic_numbers(), device=self.device)
         if any(atoms.pbc):
             cell: Optional[Tensor] = torch.tensor(
-                atoms.get_cell(), device=self.device, dtype=self.dtype
+                atoms.get_cell().array, device=self.device, dtype=self.dtype
             )
         else:
             cell = None


### PR DESCRIPTION
To fix the following error

> UserWarning: Creating a tensor from a list of numpy.ndarrays is extremely slow. Please consider converting the list to a single numpy.ndarray with numpy.array() before converting to a tensor. (Triggered internally at ../torch/csrc/utils/tensor_new.cpp:261.)

One can access the `get_cell().array` attribute instead to get a `np.ndarray` instead of `list[np.ndarray]`

potential fix for #16