### PR TITLE
Add `b97-3c`

### DIFF
--- a/torch_dftd/dftd3_xc_params.py
+++ b/torch_dftd/dftd3_xc_params.py
@@ -122,6 +122,10 @@ def get_dftd3_default_params(
             rs6 = 0.5545
             s18 = 2.2609
             rs18 = 3.2297
+        elif xc == "b97-3c":
+            rs6 = 0.3700
+            s18 = 1.5000
+            rs18 = 4.1000
         elif xc == "pbe":
             rs6 = 0.4289
             s18 = 0.7875


### PR DESCRIPTION
This PR adds paramaters for https://pubs.aip.org/aip/jcp/article/148/6/064104/196461/B97-3c-A-revised-low-cost-variant-of-the-B97-D.

Also see CP2K implementation:

https://github.com/cp2k/cp2k/blob/7123f6cb9512cd8f56af81252de383ca40d906e7/src/qs_dispersion_pairpot.F#L877-L881