### PR TITLE
Add rscan and r2scan parameters to DFTD3 XC parameters

### DIFF
--- a/torch_dftd/dftd3_xc_params.py
+++ b/torch_dftd/dftd3_xc_params.py
@@ -339,7 +339,7 @@ def get_dftd3_default_params(
             s18 = 0.7898
             rs18 = 5.7308
             # Parameters are taken from Table 1 of ref:
-            # https://pubs.aip.org/aip/jcp/article/154/6/061101/199772/r2SCAN-D4-Dispersion-corrected-meta-generalized
+            # https://doi.org/10.1063/5.0041008
         else:
             raise ValueError(f"[ERROR] Unexpected value xc={xc}")
     elif damping == "zero":

--- a/torch_dftd/dftd3_xc_params.py
+++ b/torch_dftd/dftd3_xc_params.py
@@ -328,6 +328,18 @@ def get_dftd3_default_params(
             rs6 = 0.4860
             s18 = 0.0000
             rs18 = 4.5000
+        elif xc == "rscan":
+            rs6 = 0.4702
+            s18 = 1.0886
+            rs18 = 5.7341
+            # Parameters are taken from Table 1 of ref:
+            # https://pubs.aip.org/aip/jcp/article/154/6/061101/199772/r2SCAN-D4-Dispersion-corrected-meta-generalized
+        elif xc == "r2scan":
+            rs6 = 0.4948
+            s18 = 0.7898
+            rs18 = 5.7308
+            # Parameters are taken from Table 1 of ref:
+            # https://pubs.aip.org/aip/jcp/article/154/6/061101/199772/r2SCAN-D4-Dispersion-corrected-meta-generalized
         else:
             raise ValueError(f"[ERROR] Unexpected value xc={xc}")
     elif damping == "zero":

--- a/torch_dftd/dftd3_xc_params.py
+++ b/torch_dftd/dftd3_xc_params.py
@@ -333,7 +333,7 @@ def get_dftd3_default_params(
             s18 = 1.0886
             rs18 = 5.7341
             # Parameters are taken from Table 1 of ref:
-            # https://pubs.aip.org/aip/jcp/article/154/6/061101/199772/r2SCAN-D4-Dispersion-corrected-meta-generalized
+            # https://doi.org/10.1063/5.0041008
         elif xc == "r2scan":
             rs6 = 0.4948
             s18 = 0.7898


### PR DESCRIPTION
# What
Add rscan and r2scan parameters to DFTD3 XC parameters.

# Why
To use rscan/r2scan D3 correction

# Ref
https://pubs.aip.org/aip/jcp/article/154/6/061101/199772/r2SCAN-D4-Dispersion-corrected-meta-generalized