### PR TITLE
hotfix: add long_description and long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
     name="torch-dftd",
     version=__version__,  # NOQA
     description="pytorch implementation of dftd2 & dftd3",
+    long_description="pytorch implementation of dftd2 & dftd3",
+    long_description_content_type="text/plain",
     packages=find_packages(),
     setup_requires=setup_requires,
     install_requires=install_requires,


### PR DESCRIPTION
🔗 https://github.com/pfnet-research/torch-dftd/actions/runs/11964053355/job/33355683407

Let me set a long description same as description, rather than disabling metadata check.

✅ 

```
> twine check dist/*
Checking dist/torch_dftd-0.5.0-py3-none-any.whl: PASSED
```